### PR TITLE
Added HoneyDB integration for all services.

### DIFF
--- a/api_app/script_analyzers/observable_analyzers/honeydb.py
+++ b/api_app/script_analyzers/observable_analyzers/honeydb.py
@@ -15,10 +15,12 @@ def run(analyzer_name, job_id, observable_name, observable_classification, addit
                 "".format(analyzer_name, job_id, observable_name))
     report = general.get_basic_report_template(analyzer_name)
     try:
-        api_key_name = additional_config_params.get('api_key_name', 'HONEYDB_API_KEY')
-        api_id_name = additional_config_params.get('api_id_name', 'HONEYDB_API_ID')
+        api_key_name = additional_config_params.get("api_key_name", "HONEYDB_API_KEY")
+        api_id_name = additional_config_params.get("api_id_name", "HONEYDB_API_ID")
+        api_endpoint_name = additional_config_params.get("api_endpoint_name", "HONEYDB_API_ENDPOINT")
         api_key = secrets.get_secret(api_key_name)
         api_id = secrets.get_secret(api_id_name)
+        api_endpoint = secrets.get_secret(api_endpoint_name) or "nodes" # specifying `/nodes` as the default endpoint.
         if not api_key:
             raise AnalyzerRunException("no HoneyDB API Key retrieved")
         if not api_id:
@@ -28,7 +30,12 @@ def run(analyzer_name, job_id, observable_name, observable_classification, addit
             'X-HoneyDb-ApiKey': api_key,
             'X-HoneyDb-ApiId': api_id
         }
-        url = f'https://honeydb.io/api/twitter-threat-feed/{observable_name}'
+      
+        if api_endpoint=="twitter-threat-feed":
+            url = f"https://honeydb.io/api/twitter-threat-feed/{observable_name}"
+        else:
+            url = f"https://honeydb.io/api/{api_endpoint}"
+
         response = requests.get(url, headers=headers)
         response.raise_for_status()
 

--- a/api_app/tests.py
+++ b/api_app/tests.py
@@ -10,7 +10,7 @@ from api_app.script_analyzers.file_analyzers import file_info, pe_info, doc_info
     cuckoo_scan, yara_scan, vt3_scan, strings_info, rtf_info
 from api_app.script_analyzers.observable_analyzers import abuseipdb, shodan, fortiguard, maxmind, greynoise, googlesf, otx, \
     talos, tor, circl_pssl, circl_pdns, robtex_ip, robtex_fdns, robtex_rdns, vt2_get, ha_get, vt3_get, misp, dnsdb,\
-    honeydb_twitter_scan, hunter
+    honeydb, hunter
 
 from api_app import crons
 from api_app.models import Job
@@ -170,7 +170,7 @@ class IPAnalyzersTests(TestCase):
         self.assertEqual(report.get('success', False), True)
 
     def test_honeydb(self):
-        report = honeydb_twitter_scan.run("HoneyDB", self.job_id, self.observable_name, self.observable_classification,
+        report = honeydb.run("HoneyDB", self.job_id, self.observable_name, self.observable_classification,
                                           {})
         self.assertEqual(report.get('success', False), True)
 

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -155,10 +155,11 @@
         "type": "observable",
         "observable_supported": ["ip"],
         "external_service": true,
-        "python_module": "honeydb_twitter_scan_run",
+        "python_module": "honeydb_run",
         "additional_config_params": {
             "api_key_name": "HONEYDB_API_KEY",
-            "api_id_name": "HONEYDB_API_ID"
+            "api_id_name": "HONEYDB_API_ID",
+            "api_endpoint_name": "HONEYDB_API_ENDPOINT"
         }
     },
     "Hunter": {

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -44,7 +44,8 @@ Optional variables needed to enable specific analyzers:
 * FIRST_MISP_API: FIRST MISP API key
 * FIRST_MISP_URL: FIRST MISP URL
 * CUCKOO_URL: your cuckoo instance URL
-* HONEYDB_API_ID & HONEYDB_API_KEY: HoneyDB credentials
+* HONEYDB_API_ID & HONEYDB_API_KEY: HoneyDB API credentials
+* HONEYDB_API_ENDPOINT: Specify the HoneyDB's API service you wish to call. Here's the full [list](https://honeydb.io/threats).
 
 ### Database configuration
 Before running the project, you must populate the basic configuration for PostgreSQL.

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -63,7 +63,7 @@ The following is the list of the available analyzers you can run out-of-the-box:
 * MISPFIRST: scan an observable on the FIRST MISP instance
 * DNSDB: scan an observable against the Passive DNS Farsight Database
 * Shodan: scan an IP against Shodan IP API
-* HoneyDB: scan an IP against HoneyDB.io's Twitter Threat Feed
+* HoneyDB: HoneyDB.io's Threat Info API. Call any service from the [list of endpoints](https://honeydb.io/threats).
 * Hunter: Scans a domain name and returns set of data about the organisation, the email address found and additional information about the people owning those email addresses. 
 
 ## Analyzers customization

--- a/env_file_app_template
+++ b/env_file_app_template
@@ -20,6 +20,11 @@ DNSDB_KEY=
 # HoneyDB Threat Info Creds
 HONEYDB_API_ID=
 HONEYDB_API_KEY=
+# Specify a single endpoint from here: https://honeydb.io/threats. A few examples are given below.
+HONEYDB_API_ENDPOINT=nodes
+#HONEYDB_API_ENDPOINT=nodes/mydata
+#HONEYDB_API_ENDPOINT=twitter-threat-feed
+
 HUNTER_API_KEY=
 
 # Test tokens

--- a/intel_owl/tasks.py
+++ b/intel_owl/tasks.py
@@ -5,7 +5,7 @@ from api_app.script_analyzers.file_analyzers import doc_info, file_info, pe_info
     cuckoo_scan, yara_scan, vt3_scan, strings_info, rtf_info
 from api_app.script_analyzers.observable_analyzers import abuseipdb, fortiguard, maxmind, greynoise, googlesf, otx, \
     talos, tor, circl_pdns, circl_pssl, robtex_fdns, robtex_ip, robtex_rdns, vt2_get, ha_get, vt3_get, misp, dnsdb, \
-    shodan, honeydb_twitter_scan, hunter
+    shodan, honeydb, hunter
 
 from api_app import crons
 from api_app.script_analyzers.file_analyzers import signature_info
@@ -142,8 +142,8 @@ def vt3get_scan_run(analyzer_name, job_id, observable_name, observable_classific
 
 
 @shared_task(soft_time_limit=500)
-def honeydb_twitter_scan_run(analyzer_name, job_id, observable_name, observable_classification, additional_config_params):
-    honeydb_twitter_scan.run(analyzer_name, job_id, observable_name, observable_classification, additional_config_params)
+def honeydb_run(analyzer_name, job_id, observable_name, observable_classification, additional_config_params):
+    honeydb.run(analyzer_name, job_id, observable_name, observable_classification, additional_config_params)
 
 @shared_task(soft_time_limit=30)
 def fileinfo_run(analyzer_name, job_id, filepath, filename, md5, additional_config_params):


### PR DESCRIPTION
This is a follow-up from https://github.com/certego/IntelOwl/pull/22. The previous branch had become messy so I decided to create a new branch that was even with the original `master` repo and work from that.

Now the HoneyDB integration can be used to call any endpoint from their [list of API services](https://honeydb.io/threats). 
Necessary information has been provided in the documentation and the `env_file_app_template` file.

Please review and suggest any changes, if required.

PS - I have renamed the analyzer `honeydb_twitter_scan` to `honeydb` in the codebase because now it is not only limited to twitter scan.