### PR TITLE
HoneyDB integration added for single module

### DIFF
--- a/api_app/script_analyzers/observable_analyzers/honeydb.py
+++ b/api_app/script_analyzers/observable_analyzers/honeydb.py
@@ -15,8 +15,9 @@ def run(analyzer_name, job_id, observable_name, observable_classification, addit
                 "".format(analyzer_name, job_id, observable_name))
     report = general.get_basic_report_template(analyzer_name)
     try:
-        api_key_name = additional_config_params.get('api_key_name', 'HONEYDB_API_KEY')
-        api_id_name = additional_config_params.get('api_id_name', 'HONEYDB_API_ID')
+        api_key_name = additional_config_params.get("api_key_name", "HONEYDB_API_KEY")
+        api_id_name = additional_config_params.get("api_id_name", "HONEYDB_API_ID")
+        honeydb_analysis = additional_config_params.get("honeydb_analysis", "ip_query")
         api_key = secrets.get_secret(api_key_name)
         api_id = secrets.get_secret(api_id_name)
         if not api_key:
@@ -28,7 +29,14 @@ def run(analyzer_name, job_id, observable_name, observable_classification, addit
             'X-HoneyDb-ApiKey': api_key,
             'X-HoneyDb-ApiId': api_id
         }
-        url = f'https://honeydb.io/api/twitter-threat-feed/{observable_name}'
+      
+        if honeydb_analysis=="scan_twitter":
+            url = f"https://honeydb.io/api/twitter-threat-feed/{observable_name}"
+        elif honeydb_analysis=="ip_query":
+            url = f"https://honeydb.io/api/netinfo/lookup/{observable_name}"
+        else:
+            raise AnalyzerRunException("invalid analyzer name specified. Supported: HONEYDB_Scan_Twitter, HONEYDB_Get")
+
         response = requests.get(url, headers=headers)
         response.raise_for_status()
 

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -205,14 +205,26 @@
         "external_service": true,
         "python_module": "haget_run"
     },
-    "HoneyDB": {
+    "HoneyDB_Scan_Twitter": {
         "type": "observable",
         "observable_supported": ["ip"],
         "external_service": true,
-        "python_module": "honeydb_twitter_scan_run",
+        "python_module": "honeydb_run",
         "additional_config_params": {
             "api_key_name": "HONEYDB_API_KEY",
-            "api_id_name": "HONEYDB_API_ID"
+            "api_id_name": "HONEYDB_API_ID",
+            "honeydb_analysis": "scan_twitter"
+        }
+    },
+    "HoneyDB_Get": {
+        "type": "observable",
+        "observable_supported": ["ip"],
+        "external_service": true,
+        "python_module": "honeydb_run",
+        "additional_config_params": {
+            "api_key_name": "HONEYDB_API_KEY",
+            "api_id_name": "HONEYDB_API_ID",
+            "honeydb_analysis": "ip_query"
         }
     },
     "Hunter": {

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -46,7 +46,7 @@ Optional variables needed to enable specific analyzers:
 * MISP_KEY: your own MISP instance key
 * MISP_URL your own MISP instance URL
 * CUCKOO_URL: your cuckoo instance URL
-* HONEYDB_API_ID & HONEYDB_API_KEY: HoneyDB credentials
+* HONEYDB_API_ID & HONEYDB_API_KEY: HoneyDB API credentials
 * CENSYS_API_ID & CENSYS_API_SECRET: Censys credentials
 * ONYPHE_KEY: Onyphe.io's API Key 
 

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -67,7 +67,8 @@ The following is the list of the available analyzers you can run out-of-the-box:
 * MISPFIRST: scan an observable on the FIRST MISP instance
 * DNSDB: scan an observable against the Passive DNS Farsight Database
 * Shodan: scan an IP against Shodan API
-* HoneyDB: scan an IP against HoneyDB.io's Twitter Threat Feed
+* HoneyDB_Scan_Twitter: scan an IP against HoneyDB.io's Twitter Threat Feed
+* HoneyDB_Get: IP lookup service
 * Hunter: Scans a domain name and returns set of data about the organisation, the email address found and additional information about the people owning those email addresses. 
 * Censys_Search: scan an IP address against Censys View API
 * MalwareBazaar_Get_Observable: Check if a particular malware hash is known to MalwareBazaar
@@ -91,12 +92,3 @@ Also, you can change the name of every available analyzer based on your wishes.
 Changing other keys will break the analyzer. In that case, you should think about create a new python module or to modify an existing one.
 
 To contribute to the project, see [Contribute](./Contribute.md)
-
-
-
-
-
-
-
-
-

--- a/intel_owl/tasks.py
+++ b/intel_owl/tasks.py
@@ -5,7 +5,7 @@ from api_app.script_analyzers.file_analyzers import doc_info, file_info, pe_info
     cuckoo_scan, yara_scan, vt3_scan, strings_info, rtf_info, signature_info
 from api_app.script_analyzers.observable_analyzers import abuseipdb, fortiguard, maxmind, greynoise, googlesf, otx, \
     talos, tor, circl_pdns, circl_pssl, robtex, vt2_get, ha_get, vt3_get, misp, dnsdb, \
-    shodan, honeydb_twitter_scan, hunter, mb_get, onyphe, censys, threatminer
+    shodan, honeydb, hunter, mb_get, onyphe, censys, threatminer
 
 from api_app import crons
 
@@ -140,9 +140,9 @@ def vt3get_scan_run(analyzer_name, job_id, observable_name, observable_classific
     vt3_get.run(analyzer_name, job_id, observable_name, observable_classification, additional_config_params)
 
 
-@shared_task(soft_time_limit=500)
-def honeydb_twitter_scan_run(analyzer_name, job_id, observable_name, observable_classification, additional_config_params):
-    honeydb_twitter_scan.run(analyzer_name, job_id, observable_name, observable_classification, additional_config_params)
+@shared_task(soft_time_limit=200)
+def honeydb_run(analyzer_name, job_id, observable_name, observable_classification, additional_config_params):
+    honeydb.run(analyzer_name, job_id, observable_name, observable_classification, additional_config_params)
 
 
 @shared_task(soft_time_limit=50)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,7 +99,8 @@ class ApiTests(TestCase):
                                "GreyNoiseAlpha", "GoogleSafebrowsing", "Robtex_IP_Query",
                                "Robtex_Reverse_PDNS_Query", "TalosReputation", "OTXQuery",
                                "VirusTotal_Get_v2_Observable", "HybridAnalysis_Get_Observable", "Hunter",
-                               "HoneyDB", "Threatminer_Reports_Tagging", "Threatminer_PDNS", "ONYPHE"]
+                               "Threatminer_Reports_Tagging", "Threatminer_PDNS", "ONYPHE",
+                               "HoneyDB_Scan_Twitter", "HoneyDB_Get"]
         observable_name = os.environ.get("TEST_IP", "8.8.8.8")
         md5 = hashlib.md5(observable_name.encode('utf-8')).hexdigest()
         data = {

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -12,7 +12,7 @@ from unittest import skipIf
 from api_app.script_analyzers.observable_analyzers import abuseipdb, censys, shodan, fortiguard, maxmind,\
     greynoise, googlesf, otx, talos, tor, circl_pssl, circl_pdns,\
     robtex, vt2_get, ha_get, vt3_get, misp, dnsdb,\
-    honeydb_twitter_scan, hunter, mb_get, onyphe, threatminer
+    honeydb, hunter, mb_get, onyphe, threatminer
 
 from api_app.models import Job
 from intel_owl import settings
@@ -115,9 +115,14 @@ class IPAnalyzersTests(TestCase):
         report = threatminer.run("Threatminer", self.job_id, self.observable_name, self.observable_classification, {})
         self.assertEqual(report.get('success', False), True)
 
-    def test_honeydb(self, mock_get=None, mock_post=None):
-        report = honeydb_twitter_scan.run("HoneyDB", self.job_id, self.observable_name, self.observable_classification,
+    def test_honeydb_get(self, mock_get=None, mock_post=None):
+        report = honeydb.run("HoneyDB_Get", self.job_id, self.observable_name, self.observable_classification,
                                           {})
+        self.assertEqual(report.get('success', False), True)
+
+    def test_honeydb_scan_twitter(self, mock_get=None, mock_post=None):
+        report = honeydb.run("HoneyDB_Scan_Twitter", self.job_id, self.observable_name, self.observable_classification,
+                                        {})
         self.assertEqual(report.get('success', False), True)
 
     @skipIf(settings.MOCK_CONNECTIONS, "not working without connection")


### PR DESCRIPTION
Follow up from PR #40.

**Implementation:**
Uses a single module `honeydb.py` with 2 configurations `HoneyDB_Get` and `HoneyDB_Scan_Twitter`. 

**Fixes:**
As [stated](https://github.com/certego/IntelOwl/pull/40#issuecomment-602238102) by @mlodic in the previous PR, I have used a custom variable in `additional_config_params` instead of the analyzer's name in the conditional clause.

**Test Run:**
Test run of both configurations with pyintelowl: https://i.imgur.com/8RFRJU3.jpg